### PR TITLE
Fixed type definitions and other issues in markdown

### DIFF
--- a/godocmd.go
+++ b/godocmd.go
@@ -58,7 +58,7 @@ func GenerateMarkdown(rootDir string, out io.Writer, flags ...enums.MarkdownFlag
 		}
 	}
 
-	for i, dir := range dirs {
+	for _, dir := range dirs {
 		if cfg.verbose {
 			fmt.Fprintf(os.Stderr, "📦 Parsing package: %s\n", dir)
 		}
@@ -80,10 +80,6 @@ func GenerateMarkdown(rootDir string, out io.Writer, flags ...enums.MarkdownFlag
 		if err := format.WriteMarkdownWithOptions(docPkg, out, cfg.includePrivate, cfg.includeUndocumented); err != nil {
 			fmt.Fprintf(os.Stderr, "⚠️  Failed to write markdown for %s: %v\n", dir, err)
 			continue
-		}
-
-		if i < len(dirs)-1 {
-			fmt.Fprint(out, "\n\n---\n")
 		}
 	}
 


### PR DESCRIPTION
## Pull Request Overview

This PR improves the markdown generation for Go package documentation by refining type output and formatting.  
- Removed the unused loop index in godocmd.go and eliminated redundant markdown separators.  
- Enhanced the WriteMarkdownWithOptions function in format/markdown.go with explicit handling for various Go type definitions and updated markdown detail tags.